### PR TITLE
fix yaml to use spaces, not tabs

### DIFF
--- a/vignettes/Bioconductor_Containers_Workshop.Rmd
+++ b/vignettes/Bioconductor_Containers_Workshop.Rmd
@@ -1,10 +1,10 @@
 ---
 output:
   rmarkdown::html_document:
-	highlight: pygments
-	toc: true
-	toc_depth: 3
-	fig_width: 5
+    highlight: pygments
+    toc: true
+    toc_depth: 3
+    fig_width: 5
 vignette: >
   %\VignetteIndexEntry{Bioconductor_Containers_Workshop}
   %\VignetteEngine{knitr::rmarkdown}


### PR DESCRIPTION
Using tabs in yaml causes a failure in the bookdown build processing (which needs to remove the yaml frontmatter).